### PR TITLE
Replace ScrollView with paged content in phase cards

### DIFF
--- a/Choir/Coordinators/RESTPostchainCoordinator.swift
+++ b/Choir/Coordinators/RESTPostchainCoordinator.swift
@@ -24,6 +24,11 @@ class RESTPostchainCoordinator: PostchainCoordinator, ObservableObject {
 
     // Active message identifier to track which message is currently being processed
     var activeMessageId: UUID?
+    
+    // Implementation of the messages property
+    var messages: [Message] {
+        return currentChoirThread?.messages ?? []
+    }
 
     // ViewModel reference for updates
     weak var viewModel: PostchainViewModel?

--- a/Choir/Models/ChoirModels.swift
+++ b/Choir/Models/ChoirModels.swift
@@ -117,6 +117,12 @@ class Message: ObservableObject, Identifiable, Equatable {
     // Store the currently selected phase for this message
     // This ensures the selection persists even if the view is recreated
     @Published var selectedPhase: Phase = .action
+    
+    // Store the current page for each phase
+    @Published var phasePages: [Phase: Int] = [:]
+    
+    // Store the total pages for each phase
+    @Published var phaseTotalPages: [Phase: Int] = [:]
 
     // Each message has its own dedicated phase content dictionary
     // This ensures complete isolation between messages
@@ -157,12 +163,38 @@ class Message: ObservableObject, Identifiable, Equatable {
         // Initialize with all provided phases
         self.phaseContent = phases
 
-        // Pre-initialize all phases with empty strings
+        // Pre-initialize all phases with empty strings and page state
         for phase in Phase.allCases {
             if self.phaseContent[phase] == nil {
                 self.phaseContent[phase] = ""
             }
+            
+            // Initialize page state for each phase
+            self.phasePages[phase] = 0
+            self.phaseTotalPages[phase] = 1
         }
+    }
+    
+    // Method to get the current page for a phase
+    func getCurrentPage(for phase: Phase) -> Int {
+        return phasePages[phase] ?? 0
+    }
+    
+    // Method to set the current page for a phase
+    func setCurrentPage(_ page: Int, for phase: Phase) {
+        objectWillChange.send()
+        phasePages[phase] = page
+    }
+    
+    // Method to get the total pages for a phase
+    func getTotalPages(for phase: Phase) -> Int {
+        return phaseTotalPages[phase] ?? 1
+    }
+    
+    // Method to set the total pages for a phase
+    func setTotalPages(_ total: Int, for phase: Phase) {
+        objectWillChange.send()
+        phaseTotalPages[phase] = total
     }
 
     // Equatable conformance

--- a/Choir/Protocols/PostchainCoordinator.swift
+++ b/Choir/Protocols/PostchainCoordinator.swift
@@ -11,6 +11,9 @@ protocol PostchainCoordinator {
 
     // Message tracking
     var activeMessageId: UUID? { get set }
+    
+    // Access to messages
+    var messages: [Message] { get }
 
     // Core processing
     func process(_ input: String) async throws
@@ -34,6 +37,11 @@ class TestPostchainCoordinator: PostchainCoordinator {
     var isStreaming = false
     var activeMessageId: UUID?
     var currentChoirThread: ChoirThread?
+    
+    // Implementation of the messages property
+    var messages: [Message] {
+        return currentChoirThread?.messages ?? []
+    }
 
     required init() {}
 

--- a/Choir/ViewModels/PostchainViewModel.swift
+++ b/Choir/ViewModels/PostchainViewModel.swift
@@ -257,4 +257,17 @@ class PostchainViewModel: ObservableObject {
             webResultsByMessage[messageId] ?? []
         )
     }
+    
+    // Method to select a phase for a specific message
+    func selectPhase(_ phase: Phase, for messageId: String) {
+        // This method will be used by the UI to navigate between phases
+        // The actual implementation will depend on how the Message class is accessed
+        // For now, we'll just update the current phase in the view model
+        if messageId == activeMessageId {
+            setCurrentPhase(phase)
+        }
+        
+        // Notify any observers that might need to update their UI
+        objectWillChange.send()
+    }
 }

--- a/Choir/Views/MessageRow.swift
+++ b/Choir/Views/MessageRow.swift
@@ -73,7 +73,7 @@ struct MessageRow: View {
                 .onChange(of: viewModel.responses) { _, newResponses in
                     // No-op
                 }
-                .frame(height: 400)
+                .frame(height: 600) // Increased height to make cards taller
                 .padding(.top, 4)
                 .padding(.trailing, 40)
             }

--- a/Choir/Views/PageView.swift
+++ b/Choir/Views/PageView.swift
@@ -1,0 +1,137 @@
+import SwiftUI
+
+struct PageView: View {
+    let content: String
+    @Binding var currentPage: Int
+    @Binding var totalPages: Int
+    var textColor: Color = .primary
+    
+    // Constants for page layout
+    private let wordsPerPage = 150
+    private let pageTransition = AnyTransition.asymmetric(
+        insertion: .move(edge: .trailing),
+        removal: .move(edge: .leading)
+    )
+    
+    // Split content into pages
+    private var pages: [String] {
+        let words = content.split(separator: " ").map(String.init)
+        var result: [String] = []
+        var currentPageWords: [String] = []
+        
+        for word in words {
+            currentPageWords.append(word)
+            
+            if currentPageWords.count >= wordsPerPage {
+                result.append(currentPageWords.joined(separator: " "))
+                currentPageWords = []
+            }
+        }
+        
+        // Add the last page if there are remaining words
+        if !currentPageWords.isEmpty {
+            result.append(currentPageWords.joined(separator: " "))
+        }
+        
+        // If content is empty, add an empty page
+        if result.isEmpty {
+            result = [""]
+        }
+        
+        // Update total pages
+        DispatchQueue.main.async {
+            if self.totalPages != result.count {
+                self.totalPages = result.count
+            }
+        }
+        
+        return result
+    }
+    
+    var body: some View {
+        ZStack {
+            // Show the current page
+            if !pages.isEmpty && currentPage < pages.count {
+                Text(pages[currentPage])
+                    .font(.body)
+                    .lineSpacing(5)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .foregroundColor(textColor)
+                    .id("page_\(currentPage)") // Force view recreation when page changes
+                    .transition(pageTransition)
+            } else {
+                Text("No content available")
+                    .foregroundColor(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: currentPage)
+        .onAppear {
+            // Update total pages when the view appears
+            if totalPages != pages.count {
+                totalPages = pages.count
+            }
+            
+            // Ensure current page is valid
+            if currentPage >= pages.count && pages.count > 0 {
+                currentPage = pages.count - 1
+            }
+        }
+    }
+}
+
+#Preview {
+    struct PageViewPreview: View {
+        @State private var currentPage = 0
+        @State private var totalPages = 1
+        
+        var body: some View {
+            VStack {
+                PageView(
+                    content: "This is a sample text for the page view. It demonstrates how the content is split into multiple pages based on the number of words. This is page 1 of the content. Let's add more text to see how it handles pagination. The page view should automatically split this text into multiple pages and allow navigation between them using the arrow buttons below the content area. This is the end of page 1. Now let's add even more text to create page 2. This text should appear on the second page when the user navigates to it. The transition between pages should be smooth and pleasant. This is the end of page 2. Let's add more text for page 3. This text should appear on the third page. The page view should handle an arbitrary number of pages based on the content length.",
+                    currentPage: $currentPage,
+                    totalPages: $totalPages
+                )
+                .frame(height: 300)
+                .padding()
+                .background(Color(.systemBackground))
+                .cornerRadius(12)
+                .shadow(radius: 5)
+                
+                HStack {
+                    Button(action: {
+                        if currentPage > 0 {
+                            withAnimation {
+                                currentPage -= 1
+                            }
+                        }
+                    }) {
+                        Image(systemName: "chevron.left")
+                            .padding()
+                            .background(Circle().fill(Color.blue.opacity(0.1)))
+                    }
+                    .disabled(currentPage == 0)
+                    
+                    Text("\(currentPage + 1) / \(totalPages)")
+                        .padding(.horizontal)
+                    
+                    Button(action: {
+                        if currentPage < totalPages - 1 {
+                            withAnimation {
+                                currentPage += 1
+                            }
+                        }
+                    }) {
+                        Image(systemName: "chevron.right")
+                            .padding()
+                            .background(Circle().fill(Color.blue.opacity(0.1)))
+                    }
+                    .disabled(currentPage == totalPages - 1)
+                }
+                .padding()
+            }
+        }
+    }
+    
+    return PageViewPreview()
+}

--- a/Choir/Views/PostchainView.swift
+++ b/Choir/Views/PostchainView.swift
@@ -101,8 +101,10 @@ struct PostchainView: View {
                             print("PostchainView: User tapped to select phase: \(phase)")
                             
                             // Update the view model's current phase if this is the active message
-                            if let messageId = message.id.uuidString, messageId == viewModel.activeMessageId {
-                                viewModel.selectPhase(phase, for: messageId)
+                            if let message = message, 
+                               let messageIdStr = messageId,
+                               messageIdStr == viewModel.activeMessageId {
+                                viewModel.selectPhase(phase, for: messageIdStr)
                             }
                         }
                     }
@@ -132,8 +134,10 @@ struct PostchainView: View {
                                 }
                                 
                                 // Update the view model's current phase if this is the active message
-                                if let messageId = message.id.uuidString, messageId == viewModel.activeMessageId {
-                                    viewModel.selectPhase(availablePhases[targetIndex], for: messageId)
+                                if let message = message,
+                                   let messageIdStr = messageId,
+                                   messageIdStr == viewModel.activeMessageId {
+                                    viewModel.selectPhase(availablePhases[targetIndex], for: messageIdStr)
                                 }
                             } else {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -389,8 +393,14 @@ struct PhaseCard: View {
                     } else {
                         PageView(
                             content: content,
-                            currentPage: $currentPage,
-                            totalPages: $totalPages,
+                            currentPage: Binding<Int>(
+                                get: { currentPage },
+                                set: { currentPage = $0 }
+                            ),
+                            totalPages: Binding<Int>(
+                                get: { totalPages },
+                                set: { totalPages = $0 }
+                            ),
                             textColor: primaryTextColor
                         )
                         .transition(.asymmetric(
@@ -444,8 +454,8 @@ struct PhaseCard: View {
                                 }
                                 
                                 // Also update the view model if this is the active message
-                                if let messageId = messageId, messageId == viewModel.activeMessageId {
-                                    viewModel.selectPhase(previousPhase, for: messageId)
+                                if let messageIdStr = messageId, messageIdStr == viewModel.activeMessageId {
+                                    viewModel.selectPhase(previousPhase, for: messageIdStr)
                                 }
                             }
                         }
@@ -479,8 +489,8 @@ struct PhaseCard: View {
                                 }
                                 
                                 // Also update the view model if this is the active message
-                                if let messageId = messageId, messageId == viewModel.activeMessageId {
-                                    viewModel.selectPhase(nextPhase, for: messageId)
+                                if let messageIdStr = messageId, messageIdStr == viewModel.activeMessageId {
+                                    viewModel.selectPhase(nextPhase, for: messageIdStr)
                                 }
                             }
                         }

--- a/Choir/Views/PostchainView.swift
+++ b/Choir/Views/PostchainView.swift
@@ -101,10 +101,11 @@ struct PostchainView: View {
                             print("PostchainView: User tapped to select phase: \(phase)")
                             
                             // Update the view model's current phase if this is the active message
-                            if let message = message, 
-                               let messageIdStr = messageId,
-                               messageIdStr == viewModel.activeMessageId {
-                                viewModel.selectPhase(phase, for: messageIdStr)
+                            if let message = message {
+                                let messageIdStr = message.id.uuidString
+                                if messageIdStr == viewModel.activeMessageId {
+                                    viewModel.selectPhase(phase, for: messageIdStr)
+                                }
                             }
                         }
                     }
@@ -134,10 +135,11 @@ struct PostchainView: View {
                                 }
                                 
                                 // Update the view model's current phase if this is the active message
-                                if let message = message,
-                                   let messageIdStr = messageId,
-                                   messageIdStr == viewModel.activeMessageId {
-                                    viewModel.selectPhase(availablePhases[targetIndex], for: messageIdStr)
+                                if let message = message {
+                                    let messageIdStr = message.id.uuidString
+                                    if messageIdStr == viewModel.activeMessageId {
+                                        viewModel.selectPhase(availablePhases[targetIndex], for: messageIdStr)
+                                    }
                                 }
                             } else {
                                 withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
@@ -394,12 +396,20 @@ struct PhaseCard: View {
                         PageView(
                             content: content,
                             currentPage: Binding<Int>(
-                                get: { currentPage },
-                                set: { currentPage = $0 }
+                                get: { self.currentPage },
+                                set: { newValue in
+                                    if let message = self.message {
+                                        message.setCurrentPage(newValue, for: self.phase)
+                                    }
+                                }
                             ),
                             totalPages: Binding<Int>(
-                                get: { totalPages },
-                                set: { totalPages = $0 }
+                                get: { self.totalPages },
+                                set: { newValue in
+                                    if let message = self.message {
+                                        message.setTotalPages(newValue, for: self.phase)
+                                    }
+                                }
                             ),
                             textColor: primaryTextColor
                         )
@@ -442,7 +452,9 @@ struct PhaseCard: View {
                     Button(action: {
                         if currentPage > 0 {
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                currentPage -= 1
+                                if let message = message {
+                                    message.setCurrentPage(currentPage - 1, for: phase)
+                                }
                             }
                         } else if let previousPhaseIndex = Phase.allCases.firstIndex(of: phase), 
                                   previousPhaseIndex > 0 {
@@ -454,8 +466,11 @@ struct PhaseCard: View {
                                 }
                                 
                                 // Also update the view model if this is the active message
-                                if let messageIdStr = messageId, messageIdStr == viewModel.activeMessageId {
-                                    viewModel.selectPhase(previousPhase, for: messageIdStr)
+                                if let message = message {
+                                    let messageIdStr = message.id.uuidString
+                                    if messageIdStr == viewModel.activeMessageId {
+                                        viewModel.selectPhase(previousPhase, for: messageIdStr)
+                                    }
                                 }
                             }
                         }
@@ -477,7 +492,9 @@ struct PhaseCard: View {
                     Button(action: {
                         if currentPage < totalPages - 1 {
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
-                                currentPage += 1
+                                if let message = message {
+                                    message.setCurrentPage(currentPage + 1, for: phase)
+                                }
                             }
                         } else if let nextPhaseIndex = Phase.allCases.firstIndex(of: phase), 
                                   nextPhaseIndex < Phase.allCases.count - 1 {
@@ -489,8 +506,11 @@ struct PhaseCard: View {
                                 }
                                 
                                 // Also update the view model if this is the active message
-                                if let messageIdStr = messageId, messageIdStr == viewModel.activeMessageId {
-                                    viewModel.selectPhase(nextPhase, for: messageIdStr)
+                                if let message = message {
+                                    let messageIdStr = message.id.uuidString
+                                    if messageIdStr == viewModel.activeMessageId {
+                                        viewModel.selectPhase(nextPhase, for: messageIdStr)
+                                    }
                                 }
                             }
                         }
@@ -526,7 +546,7 @@ struct PhaseCard: View {
             // Only reset to first page when the card first appears
             // This ensures we maintain page state during re-renders
             if let message = message, message.getCurrentPage(for: phase) == 0 {
-                currentPage = 0
+                message.setCurrentPage(0, for: phase)
             }
         }
     }


### PR DESCRIPTION
This PR replaces the ScrollView in phase cards with a paged content view that has pleasant page-turning animations. Key changes include:

- Created a new PageView component that splits content into pages based on word count
- Added page navigation controls with arrows beneath the phase cards
- Implemented page state persistence in the Message class to maintain page position during re-renders
- Added ability to navigate between phases when reaching the first/last page of a phase
- Increased the height of phase cards to provide more content space
- Ensured smooth transitions between pages with spring animations

The implementation maintains the special case handling for the Experience phase while providing a more pleasant reading experience for all other phases.