### PR TITLE
Add context menus to phase cards and user messages for copy/select text

### DIFF
--- a/Choir/Views/MessageRow.swift
+++ b/Choir/Views/MessageRow.swift
@@ -11,6 +11,7 @@ struct MessageRow: View {
         self.isProcessing = isProcessing
         self.viewModel = viewModel
     }
+@StateObject private var textSelectionManager = TextSelectionManager.shared
 
     var body: some View {
         VStack(alignment: message.isUser ? .trailing : .leading, spacing: 8) {
@@ -43,6 +44,14 @@ struct MessageRow: View {
                 .background(Color.accentColor)
                 .foregroundColor(.white)
                 .cornerRadius(16) // Use standard cornerRadius
+.contextMenu {
+    Button("Copy Text") {
+        UIPasteboard.general.string = message.content
+    }
+    Button("Select Text...") {
+        textSelectionManager.showSheet(withText: message.content)
+    }
+}
                 .padding(.leading, 40)
             }
             // AI messages - directly show the chorus cycle

--- a/Choir/Views/PhaseCard.swift
+++ b/Choir/Views/PhaseCard.swift
@@ -62,10 +62,22 @@ struct PhaseCard: View {
     }
 
     // --- Body ---
+@StateObject private var textSelectionManager = TextSelectionManager.shared
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
+        }
+        .contextMenu {
+            Button("Copy Text") {
+                let content = message.getPhaseContent(phase)
+                UIPasteboard.general.string = content
+            }
+            Button("Select Text...") {
+                let content = message.getPhaseContent(phase)
+                textSelectionManager.showSheet(withText: content)
+            }
+        }
             HStack {
                 Image(systemName: phase.symbol)
                     .imageScale(.medium)
@@ -204,6 +216,16 @@ struct PhaseCard: View {
                 .stroke(overlayStrokeColor, lineWidth: overlayLineWidth)
         )
         .padding(.horizontal, 4)
+.contextMenu {
+    Button("Copy Text") {
+        let content = message.getPhaseContent(phase)
+        UIPasteboard.general.string = content
+    }
+    Button("Select Text...") {
+        let content = message.getPhaseContent(phase)
+        textSelectionManager.showSheet(withText: content)
+    }
+}
     }
 }
 


### PR DESCRIPTION
This PR adds long-press context menus to phase cards and user message bubbles. The menus allow users to copy the text or open the existing global text selection sheet for easier selection and copying.\n\nThe implementation reuses the existing TextSelectionManager and sheet infrastructure, ensuring a consistent experience across the app.