### PR TITLE
feat: Unified pagination for experience phases

### DIFF
--- a/Choir/Views/PhaseCard.swift
+++ b/Choir/Views/PhaseCard.swift
@@ -103,9 +103,9 @@ struct PhaseCard: View {
                     // Determine which view to show based on the phase
                     switch phase {
                     case .experienceVectors, .experienceWeb:
-                        let results = phase == .experienceVectors ? 
-                            message.vectorSearchResults.map { .vector($0) } :
-                            message.webSearchResults.map { .web($0) }
+                        let results: [UnifiedSearchResult] = phase == .experienceVectors ? 
+                            message.vectorSearchResults.map { UnifiedSearchResult.vector($0) } :
+                            message.webSearchResults.map { UnifiedSearchResult.web($0) }
                         
                         UnifiedPaginatedView(
                             textContent: content,

--- a/Choir/Views/PhaseCard.swift
+++ b/Choir/Views/PhaseCard.swift
@@ -102,44 +102,34 @@ struct PhaseCard: View {
                 GeometryReader { geometry in
                     // Determine which view to show based on the phase
                     switch phase {
-                    case .experienceVectors:
-                         // Show Vector Search Results
-                         SearchResultListView(
-                             title: "Vector Documents",
-                             icon: "doc.text.magnifyingglass",
-                             results: message.vectorSearchResults.map { .vector($0) }, // Convert to enum case
-                             currentPage: pageBinding,
-                             availableSize: geometry.size,
-                             onNavigateToPreviousPhase: createNavigationHandler(direction: .previous),
-                             onNavigateToNextPhase: createNavigationHandler(direction: .next)
-                         )
-
-                    case .experienceWeb:
-                         // Show Web Search Results
-                         SearchResultListView(
-                            title: "Web Search Results",
-                             icon: "network",
-                            results: message.webSearchResults.map { .web($0) }, // Convert to enum case
-                             currentPage: pageBinding,
+                    case .experienceVectors, .experienceWeb:
+                        let results = phase == .experienceVectors ? 
+                            message.vectorSearchResults.map { .vector($0) } :
+                            message.webSearchResults.map { .web($0) }
+                        
+                        UnifiedPaginatedView(
+                            textContent: content,
+                            searchResults: results,
+                            currentPage: pageBinding,
                             availableSize: geometry.size,
-                             onNavigateToPreviousPhase: createNavigationHandler(direction: .previous),
-                             onNavigateToNextPhase: createNavigationHandler(direction: .next)
-                         )
+                            onNavigateToPreviousPhase: createNavigationHandler(direction: .previous),
+                            onNavigateToNextPhase: createNavigationHandler(direction: .next)
+                        )
 
                     default:
-                         // Show Paginated Text for all other phases with content
+                        // Show Paginated Text for all other phases with content
                         if !content.isEmpty {
-                             PaginatedTextView(
-                                 text: content,
-                                 availableSize: geometry.size,
-                                 currentPage: pageBinding,
-                                 onNavigateToPreviousPhase: createNavigationHandler(direction: .previous),
-                                 onNavigateToNextPhase: createNavigationHandler(direction: .next)
-                             )
-                         } else {
-                             // Should not happen often due to outer check, but safety fallback
-                             emptyContentView
-                         }
+                            PaginatedTextView(
+                                text: content,
+                                availableSize: geometry.size,
+                                currentPage: pageBinding,
+                                onNavigateToPreviousPhase: createNavigationHandler(direction: .previous),
+                                onNavigateToNextPhase: createNavigationHandler(direction: .next)
+                            )
+                        } else {
+                            // Should not happen often due to outer check, but safety fallback
+                            emptyContentView
+                        }
                     }
                 }
             } else if isLoading {

--- a/Choir/Views/SearchResultListView.swift
+++ b/Choir/Views/SearchResultListView.swift
@@ -186,13 +186,13 @@ struct PaginationControls: View {
             Button(action: {
                 if currentPage > 0 {
                     currentPage -= 1
-                } else {
-                    onNavigateToPreviousPhase?()
+                } else if let navigateToPrevious = onNavigateToPreviousPhase {
+                    navigateToPrevious()
                 }
             }) {
                 Image(systemName: "chevron.left")
                     .imageScale(.small)
-                    .padding(4) // Add padding for larger tap area
+                    .padding(4)
             }
             .disabled(currentPage <= 0 && onNavigateToPreviousPhase == nil)
             .foregroundColor(currentPage <= 0 && onNavigateToPreviousPhase == nil ? .gray : .accentColor)
@@ -208,24 +208,23 @@ struct PaginationControls: View {
             Button(action: {
                 if currentPage < totalPages - 1 {
                     currentPage += 1
-                } else {
-                    onNavigateToNextPhase?()
+                } else if let navigateToNext = onNavigateToNextPhase {
+                    navigateToNext()
                 }
             }) {
                 Image(systemName: "chevron.right")
                     .imageScale(.small)
-                    .padding(4) // Add padding for larger tap area
+                    .padding(4)
             }
             .disabled(currentPage >= totalPages - 1 && onNavigateToNextPhase == nil)
             .foregroundColor(currentPage >= totalPages - 1 && onNavigateToNextPhase == nil ? .gray : .accentColor)
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 4)
-        .background(Color(.tertiarySystemBackground).opacity(0.7)) // Use tertiary for distinction
+        .background(Color(.secondarySystemBackground).opacity(0.6))
         .cornerRadius(8)
-        .padding(.horizontal, 5) // Match list padding
-        .padding(.bottom, 5)
-        .padding(.top, 2) // Less top padding
+        .padding(.bottom, 2)
+        .frame(height: 36)
     }
 }
 

--- a/Choir/Views/UnifiedPaginatedView.swift
+++ b/Choir/Views/UnifiedPaginatedView.swift
@@ -26,7 +26,7 @@ struct UnifiedPaginatedView: View {
     
     var body: some View {
         VStack(spacing: 0) {
-            if !allPages.isEmpty && currentPage &lt; allPages.count {
+            if !allPages.isEmpty && currentPage < allPages.count {
                 switch allPages[currentPage] {
                 case .text(let textPage):
                     Text(textPage)
@@ -71,7 +71,7 @@ struct UnifiedPaginatedView: View {
         
         // Calculate result pages
         let resultPages = stride(from: 0, to: searchResults.count, by: itemsPerPage).map {
-            Array(searchResults[$0..&lt;min($0 + itemsPerPage, searchResults.count)])
+            Array(searchResults[$0..<min($0 + itemsPerPage, searchResults.count)])
         }
         
         // Combine sequences
@@ -99,7 +99,7 @@ struct UnifiedPaginatedView: View {
             )
             pages.append(pageText)
             
-            if pageText.count &lt; remainingText.count {
+            if pageText.count < remainingText.count {
                 let index = remainingText.index(
                     remainingText.startIndex, 
                     offsetBy: pageText.count

--- a/Choir/Views/UnifiedPaginatedView.swift
+++ b/Choir/Views/UnifiedPaginatedView.swift
@@ -33,8 +33,8 @@ struct UnifiedPaginatedView: View {
                         .font(.body)
                         .lineSpacing(4)
                         .padding([.horizontal, .top], 4)
-                        .frame(maxWidth: .infinity, 
-                               maxHeight: .infinity, 
+                        .frame(maxWidth: .infinity,
+                               maxHeight: .infinity,
                                alignment: .topLeading)
                     
                 case .results(let results):
@@ -50,8 +50,11 @@ struct UnifiedPaginatedView: View {
                         }
                     }
                     .padding(.horizontal, 5)
+                    .frame(maxHeight: .infinity)
                 }
             }
+            
+            Spacer(minLength: 0)
             
             PaginationControls(
                 currentPage: $currentPage,
@@ -60,6 +63,7 @@ struct UnifiedPaginatedView: View {
                 onNavigateToNextPhase: onNavigateToNextPhase
             )
         }
+        .frame(maxHeight: .infinity)
         .onAppear(perform: calculateAllPages)
         .onChange(of: textContent) { _ in calculateAllPages() }
         .onChange(of: searchResults) { _ in calculateAllPages() }

--- a/Choir/Views/UnifiedPaginatedView.swift
+++ b/Choir/Views/UnifiedPaginatedView.swift
@@ -1,0 +1,115 @@
+import SwiftUI
+
+enum PageContent: Identifiable {
+    case text(String)
+    case results([UnifiedSearchResult])
+    
+    var id: String {
+        switch self {
+        case .text(let content): return "text-\(content.hashValue)"
+        case .results(let results): return "results-\(results.hashValue)"
+        }
+    }
+}
+
+struct UnifiedPaginatedView: View {
+    let textContent: String
+    let searchResults: [UnifiedSearchResult]
+    @Binding var currentPage: Int
+    let availableSize: CGSize
+    var onNavigateToPreviousPhase: (() -> Void)?
+    var onNavigateToNextPhase: (() -> Void)?
+    
+    @State private var allPages: [PageContent] = []
+    @State private var totalPages: Int = 1
+    private let itemsPerPage: Int = 5
+    
+    var body: some View {
+        VStack(spacing: 0) {
+            if !allPages.isEmpty && currentPage &lt; allPages.count {
+                switch allPages[currentPage] {
+                case .text(let textPage):
+                    Text(textPage)
+                        .font(.body)
+                        .lineSpacing(4)
+                        .padding([.horizontal, .top], 4)
+                        .frame(maxWidth: .infinity, 
+                               maxHeight: .infinity, 
+                               alignment: .topLeading)
+                    
+                case .results(let results):
+                    VStack(alignment: .leading, spacing: 10) {
+                        ForEach(results) { result in
+                            switch result {
+                            case .vector(let vectorResult):
+                                VectorResultCard(result: vectorResult)
+                            case .web(let webResult):
+                                WebResultCard(result: webResult, 
+                                            openURL: OpenURLAction { _ in .systemAction })
+                            }
+                        }
+                    }
+                    .padding(.horizontal, 5)
+                }
+            }
+            
+            PaginationControls(
+                currentPage: $currentPage,
+                totalPages: $totalPages,
+                onNavigateToPreviousPhase: onNavigateToPreviousPhase,
+                onNavigateToNextPhase: onNavigateToNextPhase
+            )
+        }
+        .onAppear(perform: calculateAllPages)
+        .onChange(of: textContent) { _ in calculateAllPages() }
+        .onChange(of: searchResults) { _ in calculateAllPages() }
+    }
+    
+    private func calculateAllPages() {
+        // Calculate text pages
+        let textPages = splitTextIntoPages(textContent, size: availableSize)
+        
+        // Calculate result pages
+        let resultPages = stride(from: 0, to: searchResults.count, by: itemsPerPage).map {
+            Array(searchResults[$0..&lt;min($0 + itemsPerPage, searchResults.count)])
+        }
+        
+        // Combine sequences
+        allPages = textPages.map { PageContent.text($0) } + 
+                   resultPages.map { PageContent.results($0) }
+        totalPages = allPages.count
+        
+        // Ensure current page is valid
+        if currentPage >= totalPages {
+            currentPage = max(0, totalPages - 1)
+        }
+    }
+    
+    private func splitTextIntoPages(_ text: String, size: CGSize) -> [String] {
+        let measurer = TextMeasurer(sizeCategory: .medium) // Reuse from PaginatedTextView
+        let textHeight = size.height - 40 // Account for controls
+        var pages: [String] = []
+        var remainingText = text
+        
+        while !remainingText.isEmpty {
+            let pageText = measurer.fitTextToHeight(
+                text: remainingText,
+                width: size.width - 8,
+                height: textHeight
+            )
+            pages.append(pageText)
+            
+            if pageText.count &lt; remainingText.count {
+                let index = remainingText.index(
+                    remainingText.startIndex, 
+                    offsetBy: pageText.count
+                )
+                remainingText = String(remainingText[index...])
+            } else {
+                remainingText = ""
+            }
+        }
+        
+        return pages
+    }
+}

--- a/docs/levels/all.txt
+++ b/docs/levels/all.txt
@@ -61,6 +61,7 @@ tree.md
 │       │   └── Components
 │       │       ├── ThreadInputBar.swift
 │       │       └── ThreadMessageList.swift
+│       ├── UnifiedPaginatedView.swift
 │       └── WalletView.swift
 ├── Choir.xcodeproj
 │   ├── project.pbxproj
@@ -244,7 +245,7 @@ tree.md
     ├── test_api.sh
     └── test_postchain_multiturn.sh
 
-60 directories, 169 files
+60 directories, 170 files
 
 === File: docs/CHANGELOG.md ===
 

--- a/docs/levels/level0.md
+++ b/docs/levels/level0.md
@@ -61,6 +61,7 @@ tree.md
 │       │   └── Components
 │       │       ├── ThreadInputBar.swift
 │       │       └── ThreadMessageList.swift
+│       ├── UnifiedPaginatedView.swift
 │       └── WalletView.swift
 ├── Choir.xcodeproj
 │   ├── project.pbxproj
@@ -244,7 +245,7 @@ tree.md
     ├── test_api.sh
     └── test_postchain_multiturn.sh
 
-60 directories, 169 files
+60 directories, 170 files
 
 === File: docs/CHANGELOG.md ===
 

--- a/docs/tree.md
+++ b/docs/tree.md
@@ -48,6 +48,7 @@
 │       │   └── Components
 │       │       ├── ThreadInputBar.swift
 │       │       └── ThreadMessageList.swift
+│       ├── UnifiedPaginatedView.swift
 │       └── WalletView.swift
 ├── Choir.xcodeproj
 │   ├── project.pbxproj
@@ -231,4 +232,4 @@
     ├── test_api.sh
     └── test_postchain_multiturn.sh
 
-60 directories, 169 files
+60 directories, 170 files


### PR DESCRIPTION
## Changes

- Created `UnifiedPaginatedView` to combine text content and search results in a single paginated view
- Modified `PhaseCard` to use the unified view for experience phases (experienceVectors and experienceWeb)
- Maintained consistent pagination UI across all phases

## Testing

Verify that:
1. Experience phases show both text content and search results
2. Pagination works seamlessly across combined content
3. Phase navigation still works at boundaries